### PR TITLE
Initial work putting the nav and global elements into CSS Grid

### DIFF
--- a/src/css/wsu-web-identity.css
+++ b/src/css/wsu-web-identity.css
@@ -1,31 +1,45 @@
+/* animation */
+
+@keyframes fade-in {
+
+  0%   {
+		opacity: 0;
+	}
+  100% {
+		opacity: 1;
+	}
+
+}
+
+/* - */
+
+body {
+	display: grid;
+	font-family: arial, sans-serif;
+	grid-template-columns: auto 1fr;
+	grid-template-rows: auto;
+	grid-template-areas: "nav header" "nav main" "nav footer";
+	min-height: 100vh;
+}
+
 .header-global {
 	background: #fff;
 	border-bottom: 1px solid #777;
-	width: 100%;
+	grid-area: header;
 	height: 100px;
+}
+
+.navigation-main {
+	grid-area: nav;
 }
 
 .footer-global {
 	background: #fff;
 	border-top: 1px solid #777;
-	width: 100%;
+	grid-area: footer;
 	height: 20px;
 }
 
 main {
-	min-height: calc(100vh - 156px);
-}
-
-.footer-global,
-.header-global,
-main {
-	margin-left: 60px;
-	width: calc(100% - 60px);
-}
-
-.navigation-open .footer-global,
-.navigation-open .header-global,
-.navigation-open main {
-	margin-left: 300px;
-	width: calc(100% - 300px);
+	grid-area: main;
 }

--- a/src/css/wsu-web-identity.css
+++ b/src/css/wsu-web-identity.css
@@ -1,18 +1,17 @@
 /* animation */
-
 @keyframes fade-in {
 
-  0%   {
+	0%   {
 		opacity: 0;
 	}
-  100% {
+
+	100% {
 		opacity: 1;
 	}
 
 }
 
 /* - */
-
 body {
 	display: grid;
 	font-family: arial, sans-serif;

--- a/src/css/wsu-web-identity.css
+++ b/src/css/wsu-web-identity.css
@@ -1,7 +1,7 @@
 /* animation */
 @keyframes fade-in {
 
-	0%   {
+	0% {
 		opacity: 0;
 	}
 

--- a/src/css/wsu-web-navigation.css
+++ b/src/css/wsu-web-navigation.css
@@ -48,7 +48,6 @@
 }
 
 /* navigation links */
-
 .navigation-main ul {
 	list-style: none;
 	font-size: .8rem;

--- a/src/css/wsu-web-navigation.css
+++ b/src/css/wsu-web-navigation.css
@@ -1,33 +1,39 @@
 .navigation-main {
-	position: absolute;
-	width: 60px;
 	background: #404040;
-	top: 0;
-	bottom: 0;
-	left: 0;
+	position: relative;
+	width: 60px;
+	transition: width .3s ease;
+}
+
+.navigation-main > ul {
+	display: none;
+	margin-top: 120px;
+	opacity: 0;
 }
 
 .navigation-open .navigation-main {
 	width: 300px;
 }
 
-.navigation-main > ul {
-	display: none;
-	margin-top: 120px;
-}
-
 .navigation-open .navigation-main > ul {
 	display: block;
+	animation-name: fade-in;
+	animation-delay: .3s;
+	animation-duration: .2s;
+	animation-fill-mode: forwards;
+	animation-timing-function: ease;
 }
 
+/* toggle */
+
 .navigation-toggle {
+	background: transparent;
 	position: absolute;
 	display: block;
 	top: 0;
-	left: 0;
+	right: 0;
 	width: 60px;
 	height: 100%;
-	background: #404040;
 	color: #fff;
 	font-size: 1.2em;
 	border: 0;
@@ -38,14 +44,14 @@
 
 .navigation-open .navigation-toggle {
 	height: 60px;
-	width: 60px;
 	right: 10px;
 	left: initial;
 }
 
+/* navigation links */
+
 .navigation-main ul {
 	list-style: none;
-	font-family: arial, sans-serif;
 	font-size: .8rem;
 }
 
@@ -92,6 +98,7 @@
 	position: absolute;
 	top: 0;
 	right: 30px;
+	z-index: -1;
 }
 
 .navigation-main .has-items.has-items-open:after {

--- a/src/css/wsu-web-navigation.css
+++ b/src/css/wsu-web-navigation.css
@@ -25,7 +25,6 @@
 }
 
 /* toggle */
-
 .navigation-toggle {
 	background: transparent;
 	position: absolute;


### PR DESCRIPTION
The name of the branch may signify some work on the horizontal navigation, but there is no work towards that end with this pull request.


- Use CSS Grids
- turned body into a grid
- placed `header-global`, `navigation-main`, `main`, and `footer-global` into grid areas.
- added basic animation to the open and close to `navigation-main`.
- gave `.has-item` pseudo element `z-index: -1;` to prevent an overlay, however small, that would prevent the open and close from happening.